### PR TITLE
fix seeding storage

### DIFF
--- a/db_migration/config/config.js
+++ b/db_migration/config/config.js
@@ -9,6 +9,7 @@ const credentials = {
   host: process.env.DB_HOST,
   port: 5432,
   dialect: 'postgres',
+  seederStorage: 'sequelize',
 };
 
 const development = {
@@ -18,6 +19,7 @@ const development = {
   host: '192.168.0.110',
   port: 5432,
   dialect: 'postgres',
+  seederStorage: 'sequelize',
   
 };
 const test = {

--- a/db_migration/seeders/20230731094447-initial-products.js
+++ b/db_migration/seeders/20230731094447-initial-products.js
@@ -17,8 +17,6 @@ module.exports = {
   },
 
   async down (queryInterface) {
-    await queryInterface.bulkDelete(TABLE_NAME, {
-      id: data.map(({ id }) => id)
-    });
+    await queryInterface.bulkDelete(TABLE_NAME, null, {});
   }
 };


### PR DESCRIPTION
Fix db data duplication by seeding the same data twice.

Add SequelizeData table to db for saving seeding history